### PR TITLE
Fixed leaderboard

### DIFF
--- a/cogs/leveling.py
+++ b/cogs/leveling.py
@@ -61,13 +61,14 @@ class Levels(commands.Cog):
             if time_difference < 1:  # if it's a minute or less
                 return
 
-            exp = exp + up
-
             if total_exp == 0:
                 for level_mini_start in range(int(level)):
                     total_exp += math.floor(5 * (level_mini_start ^ 2) + 50 * level_mini_start + 100)
+                total_exp += exp
 
-            total_exp += exp
+            exp = exp + up
+
+            total_exp += up
 
             await posts.update_one({"user_id": message.author.id, "guild_id": message.guild.id},
                                    {"$set": {"exp": exp, "total_exp": total_exp, "message_time": new_message_time}})


### PR DESCRIPTION
Total exp is now calculated properly and as such, fixes the bug where the leaderboard displays the ranking in the wrong order